### PR TITLE
Set compile paths relative.

### DIFF
--- a/src/nglfw/compile.nim
+++ b/src/nglfw/compile.nim
@@ -24,28 +24,28 @@ else:
       {.link: "shell32.lib".}
       {.link: "user32.lib".}
     {.
-      compile: "glfw/src/win32_init.c",
-      compile: "glfw/src/win32_joystick.c",
-      compile: "glfw/src/win32_module.c",
-      compile: "glfw/src/win32_monitor.c",
-      compile: "glfw/src/win32_time.c",
-      compile: "glfw/src/win32_thread.c",
-      compile: "glfw/src/win32_window.c",
-      compile: "glfw/src/wgl_context.c",
+      compile: "../glfw/src/win32_init.c",
+      compile: "../glfw/src/win32_joystick.c",
+      compile: "../glfw/src/win32_module.c",
+      compile: "../glfw/src/win32_monitor.c",
+      compile: "../glfw/src/win32_time.c",
+      compile: "../glfw/src/win32_thread.c",
+      compile: "../glfw/src/win32_window.c",
+      compile: "../glfw/src/wgl_context.c",
     .}
     when defined(wgpu): {.passC: "-DGLFW_EXPOSE_NATIVE_WIN32".}
   elif defined(macosx):
     {.
       passC:   "-D_GLFW_COCOA",
       passL:   "-framework Cocoa -framework OpenGL -framework IOKit -framework CoreFoundation",
-      compile: "glfw/src/cocoa_init.m",
-      compile: "glfw/src/cocoa_joystick.m",
-      compile: "glfw/src/cocoa_monitor.m",
-      compile: "glfw/src/cocoa_time.c",
-      compile: "glfw/src/cocoa_window.m",
-      compile: "glfw/src/posix_module.c",
-      compile: "glfw/src/posix_thread.c",
-      compile: "glfw/src/nsgl_context.m",
+      compile: "../glfw/src/cocoa_init.m",
+      compile: "../glfw/src/cocoa_joystick.m",
+      compile: "../glfw/src/cocoa_monitor.m",
+      compile: "../glfw/src/cocoa_time.c",
+      compile: "../glfw/src/cocoa_window.m",
+      compile: "../glfw/src/posix_module.c",
+      compile: "../glfw/src/posix_thread.c",
+      compile: "../glfw/src/nsgl_context.m",
     .}
     when defined(wgpu):
       {.
@@ -62,57 +62,57 @@ else:
     when defined(wayland):
       {.
         passC: "-D_GLFW_WAYLAND",
-        compile: "glfw/src/wl_init.c",
-        compile: "glfw/src/wl_monitor.c",
-        compile: "glfw/src/wl_window.c",
-        compile: "glfw/src/posix_module.c",
-        compile: "glfw/src/posix_poll.c",
-        compile: "glfw/src/posix_thread.c",
-        compile: "glfw/src/posix_time.c",
-        compile: "glfw/src/xkb_unicode.c",
+        compile: "../glfw/src/wl_init.c",
+        compile: "../glfw/src/wl_monitor.c",
+        compile: "../glfw/src/wl_window.c",
+        compile: "../glfw/src/posix_module.c",
+        compile: "../glfw/src/posix_poll.c",
+        compile: "../glfw/src/posix_thread.c",
+        compile: "../glfw/src/posix_time.c",
+        compile: "../glfw/src/xkb_unicode.c",
       .}
       when defined(wgpu): {.passC: "-DGLFW_EXPOSE_NATIVE_WAYLAND".}
     else:
       {.
         passC: "-D_GLFW_X11",
-        compile: "glfw/src/x11_init.c",
-        compile: "glfw/src/x11_monitor.c",
-        compile: "glfw/src/x11_window.c",
-        compile: "glfw/src/xkb_unicode.c",
-        compile: "glfw/src/posix_module.c",
-        compile: "glfw/src/posix_poll.c",
-        compile: "glfw/src/posix_thread.c",
-        compile: "glfw/src/posix_time.c",
-        compile: "glfw/src/glx_context.c",
+        compile: "../glfw/src/x11_init.c",
+        compile: "../glfw/src/x11_monitor.c",
+        compile: "../glfw/src/x11_window.c",
+        compile: "../glfw/src/xkb_unicode.c",
+        compile: "../glfw/src/posix_module.c",
+        compile: "../glfw/src/posix_poll.c",
+        compile: "../glfw/src/posix_thread.c",
+        compile: "../glfw/src/posix_time.c",
+        compile: "../glfw/src/glx_context.c",
       .}
       when defined(wgpu): {.passC: "-DGLFW_EXPOSE_NATIVE_X11".}
 
-    {.compile: "glfw/src/linux_joystick.c".}
+    {.compile: "../glfw/src/linux_joystick.c".}
   else:
     # If unsupported/unknown OS, use null system
     {.
-      compile: "glfw/src/posix_module.c",
-      compile: "glfw/src/posix_poll.c",
-      compile: "glfw/src/posix_thread.c",
-      compile: "glfw/src/posix_time.c",
+      compile: "../glfw/src/posix_module.c",
+      compile: "../glfw/src/posix_poll.c",
+      compile: "../glfw/src/posix_thread.c",
+      compile: "../glfw/src/posix_time.c",
     .}
 
   # Common
   {.
-    compile: "glfw/src/context.c",
-    compile: "glfw/src/init.c",
-    compile: "glfw/src/input.c",
-    compile: "glfw/src/monitor.c",
-    compile: "glfw/src/platform.c",
-    compile: "glfw/src/vulkan.c",
-    compile: "glfw/src/window.c"
+    compile: "../glfw/src/context.c",
+    compile: "../glfw/src/init.c",
+    compile: "../glfw/src/input.c",
+    compile: "../glfw/src/monitor.c",
+    compile: "../glfw/src/platform.c",
+    compile: "../glfw/src/vulkan.c",
+    compile: "../glfw/src/window.c"
     # The time, thread and module code is shared between all backends on a given OS,
     # including the null backend, which still needs those bits to be functional
-    compile: "glfw/src/null_init.c",
-    compile: "glfw/src/null_joystick.c",
-    compile: "glfw/src/null_monitor.c",
-    compile: "glfw/src/null_window.c",
-    compile: "glfw/src/egl_context.c",
-    compile: "glfw/src/osmesa_context.c"
+    compile: "../glfw/src/null_init.c",
+    compile: "../glfw/src/null_joystick.c",
+    compile: "../glfw/src/null_monitor.c",
+    compile: "../glfw/src/null_window.c",
+    compile: "../glfw/src/egl_context.c",
+    compile: "../glfw/src/osmesa_context.c"
   .}
 


### PR DESCRIPTION
 Set compile paths relative so the library works when not used as nimble package.